### PR TITLE
Update pkcsslotd.service.in

### DIFF
--- a/misc/pkcsslotd.service.in
+++ b/misc/pkcsslotd.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Daemon which manages cryptographic hardware tokens for the openCryptoki package
-After=syslog.target
+After=local-fs.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
Update pkcsslotd.service.in to use After=local-fs.target instead of syslog.target. The syslog target doesn't exist any more.

Signed-off-by: Mark Post <mpost@suse.com>